### PR TITLE
Make Hawk.Suave compatible with Suave 1.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+﻿*.sln text eol=lf
+*.lock text eol=lf
+*.fsproj text eol=lf

--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,7 @@
 NUGET
-  remote: https://nuget.org/api/v2
+  remote: https://www.nuget.org/api/v2
   specs:
-    FsCheck (2.2.3)
+    FsCheck (2.2.4)
       FSharp.Core (>= 3.1.2.5)
     FSharp.Core (3.1.2.5)
     Fuchu (1.0.2)
@@ -12,9 +12,9 @@ NUGET
       Fuchu (>= 1.0.2.0)
     NodaTime (1.3.1)
     NuGet.CommandLine (3.3.0)
-    Suave (0.33.0)
+    Suave (1.0.0)
       FSharp.Core (>= 3.1.2.5)
-    Suave.Testing (0.33.0)
+    Suave.Testing (1.0.0)
       FSharp.Core (>= 3.1.2.5)
-      Fuchu (>= 0.6.0)
-      Suave (>= 0.33.0)
+      Fuchu (>= 1.0.2)
+      Suave (>= 1.0.0)

--- a/src/logibit.hawk.suave.tests/Hawk.fs
+++ b/src/logibit.hawk.suave.tests/Hawk.fs
@@ -16,17 +16,16 @@ open logibit.hawk.Client
 open Suave
 open Suave.Web
 open Suave.Http
-open Suave.Http.Applicatives
-open Suave.Http.Successful
-open Suave.Http.RequestErrors
-open Suave.Types
+open Suave.Logging
 open Suave.Testing
+open Suave.RequestErrors
+open Suave.Successful
 
 open NodaTime
 
 open Fuchu
 
-let runWithDefaultConfig = runWith defaultConfig
+let runWithDefaultConfig = runWith { defaultConfig with logger = Loggers.ConsoleWindowLogger(LogLevel.Warn) }
 
 let credsInner id =
   { id        = id

--- a/src/logibit.hawk.suave/Hawk.fs
+++ b/src/logibit.hawk.suave/Hawk.fs
@@ -2,8 +2,8 @@
 
 open System
 
+open Suave
 open Suave.Model
-open Suave.Types
 type private SHttpMethod = HttpMethod
 
 open logibit.hawk
@@ -156,8 +156,7 @@ let authenticate (settings : Settings<'a>)
   fun ctx ->
     match authHeader settings reqFac ctx with
     | Choice1Of2 res ->
-      (Writers.setUserData HawkDataKey res
-       >>= fCont res) ctx
+      (fCont res |> Writers.setUserData HawkDataKey) ctx
     | Choice2Of2 err ->
       fErr err ctx
 
@@ -179,8 +178,7 @@ let authenticateBewit settings reqFac fErr fCont : WebPart =
   fun ctx ->
     match authBewit settings reqFac ctx with
     | Choice1Of2 res ->
-      (Writers.setUserData HawkDataKey res
-       >>= fCont res) ctx
+      (fCont res |> Writers.setUserData HawkDataKey) ctx
     | Choice2Of2 err ->
       fErr err ctx
 


### PR DESCRIPTION
Suave is now released version 1.0 and made a bit of changes in API and namespaces. I could not make test work in Windows, still investigating
